### PR TITLE
removing ado_ext_pat variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [keepachangelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [0.3.0]
- * Fixing [#8](https://github.com/tonyskidmore/terraform-shell-azure-devops-elasticpool/issues/8)
+* Fixing [#8](https://github.com/tonyskidmore/terraform-shell-azure-devops-elasticpool/issues/8)
 
 ## [0.2.0]
 * Moved provider block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 [keepachangelog](https://keepachangelog.com/en/1.0.0/)
 
-## [0.0.2]
+## [0.3.0]
+ * Fixing [#8](https://github.com/tonyskidmore/terraform-shell-azure-devops-elasticpool/issues/8)
+
+## [0.2.0]
 * Moved provider block
 * Added unit tests to pre-commit
 * Updated example
 
-## [0.0.1]
+## [0.1.0]
 Initial version

--- a/README.md
+++ b/README.md
@@ -66,10 +66,8 @@ data "azurerm_virtual_machine_scale_set" "ado_pool" {
 }
 
 module "azure-devops-elasticpool" {
-  source  = "tonyskidmore/azure-devops-elasticpool/shell"
-  version = "0.2.0"
-  # this will be supplied by exporting TF_VAR_ado_ext_pat before running terraform
-  # this an Azure DevOps Personal Access Token to create and manage the agent pool
+  source                 = "tonyskidmore/azure-devops-elasticpool/shell"
+  version                = "0.3.0"
   ado_ext_pat            = var.ado_ext_pat
   ado_org                = var.ado_org
   ado_project            = var.ado_project
@@ -90,7 +88,6 @@ module "azure-devops-elasticpool" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ado_ext_pat"></a> [ado\_ext\_pat](#input\_ado\_ext\_pat) | Azure DevOps personal access token | `string` | n/a | yes |
 | <a name="input_ado_org"></a> [ado\_org](#input\_ado\_org) | Azure DevOps Organization name | `string` | n/a | yes |
 | <a name="input_ado_pool_auth_all_pipelines"></a> [ado\_pool\_auth\_all\_pipelines](#input\_ado\_pool\_auth\_all\_pipelines) | Setting to determine if all pipelines are authorized to use this TaskAgentPool by default (at create only) | `string` | `"True"` | no |
 | <a name="input_ado_pool_auto_provision_projects"></a> [ado\_pool\_auto\_provision\_projects](#input\_ado\_pool\_auto\_provision\_projects) | Setting to automatically provision TaskAgentQueues in every project for the new pool (at create only) | `string` | `"True"` | no |

--- a/examples/admin_password/README.md
+++ b/examples/admin_password/README.md
@@ -30,7 +30,7 @@ Requirements
 
 | Name | Source | Version |
 |------|--------|---------|
-| azure-devops-elasticpool | tonyskidmore/azure-devops-elasticpool/shell | 0.2.0 |
+| azure-devops-elasticpool | tonyskidmore/azure-devops-elasticpool/shell | 0.3.0 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -68,10 +68,8 @@ data "azurerm_virtual_machine_scale_set" "ado_pool" {
 }
 
 module "azure-devops-elasticpool" {
-  source  = "tonyskidmore/azure-devops-elasticpool/shell"
-  version = "0.2.0"
-  # this will be supplied by exporting TF_VAR_ado_ext_pat before running terraform
-  # this an Azure DevOps Personal Access Token to create and manage the agent pool
+  source                 = "tonyskidmore/azure-devops-elasticpool/shell"
+  version                = "0.3.0"
   ado_ext_pat            = var.ado_ext_pat
   ado_org                = var.ado_org
   ado_project            = var.ado_project

--- a/examples/admin_password/main.tf
+++ b/examples/admin_password/main.tf
@@ -14,10 +14,8 @@ data "azurerm_virtual_machine_scale_set" "ado_pool" {
 }
 
 module "azure-devops-elasticpool" {
-  source  = "tonyskidmore/azure-devops-elasticpool/shell"
-  version = "0.2.0"
-  # this will be supplied by exporting TF_VAR_ado_ext_pat before running terraform
-  # this an Azure DevOps Personal Access Token to create and manage the agent pool
+  source                 = "tonyskidmore/azure-devops-elasticpool/shell"
+  version                = "0.3.0"
   ado_ext_pat            = var.ado_ext_pat
   ado_org                = var.ado_org
   ado_project            = var.ado_project

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,4 @@
 # required variables
-variable "ado_ext_pat" {
-  type        = string
-  description = "Azure DevOps personal access token"
-}
 
 variable "ado_org" {
   type        = string


### PR DESCRIPTION
Closes #8 

* Removes `ado_ext_pat` variable.  Should be passed by the root module as per the [example](https://github.com/tonyskidmore/terraform-shell-azure-devops-elasticpool/blob/main/examples/admin_password/main.tf#L5-L9).